### PR TITLE
Add Redis session store

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ cd ../frontend
 npm install
 ```
 
+### 3. Levantar Redis con Docker
+
+```bash
+docker compose up -d redis
+```
+
 ## 🏃‍♂️ Cómo Ejecutar
 
 ### 1. Ejecutar el Backend

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,9 @@
   "dependencies": {
     "express": "^4.18.2",
     "express-session": "^1.17.3",
-    "cors": "^2.8.5"
+    "cors": "^2.8.5",
+    "connect-redis": "^7.0.0",
+    "redis": "^4.6.7"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,9 +1,18 @@
 import express from 'express';
 import session from 'express-session';
+import connectRedis from 'connect-redis';
+import { createClient } from 'redis';
 import cors from 'cors';
 
 const app = express();
 const PORT = 3000;
+
+// 🔌 Configurar Redis
+const RedisStore = connectRedis(session);
+const redisClient = createClient({ legacyMode: true });
+redisClient.connect()
+  .then(() => logWithEmoji('📡', 'Conectado a Redis'))
+  .catch((err) => logWithEmoji('❌', 'Error conectando a Redis', { error: err.message }));
 
 // 🎨 Función para logs divertidos
 const logWithEmoji = (emoji: string, message: string, data?: any) => {
@@ -34,6 +43,7 @@ app.use(express.json());
 // 🔑 Configuración de sesiones
 logWithEmoji('🔧', 'Configurando middleware de sesiones...', {
   secret: 'mi-super-secreto-para-firmar-cookies',
+  store: 'Redis',
   cookie: {
     secure: false,
     httpOnly: true,
@@ -42,6 +52,7 @@ logWithEmoji('🔧', 'Configurando middleware de sesiones...', {
 });
 
 app.use(session({
+  store: new RedisStore({ client: redisClient }),
   secret: 'mi-super-secreto-para-firmar-cookies', // En producción usar variable de entorno
   resave: false,
   saveUninitialized: false,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+volumes:
+  redis_data:


### PR DESCRIPTION
## Summary
- use Redis as the session store
- add docker-compose file with a Redis service
- document how to start Redis with Docker

## Testing
- `npm --prefix backend run build` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_686011f915888321bc848008172fac2b